### PR TITLE
Wrap extension param on nodemon

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,9 @@
+{
+ "ignore":[
+    ".git",
+    "node_modules/**/node_modules",
+    "*bundle.js",
+    "*bundle.js.map"
+ ],
+ "ext":"*"
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "webpack --config client/webpack.config.js",
     "build:watch": "nodemon --watch client --watch components --ignore *bundle.js --ignore *bundle.js.map -e * --exec npm run build",
     "server": "node server/server.js",
-    "server:watch": "nodemon --delay 3 --watch server -e * --exec npm run server",
+    "server:watch": "nodemon --delay 3 --watch server -e '*' --exec npm run server",
     "dev": " npm-run-all --parallel build:watch server:watch",
     "start": "npm-run-all --serial build server"
   },

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   },
   "scripts": {
     "build": "webpack --config client/webpack.config.js",
-    "build:watch": "nodemon --watch client --watch components --ignore *bundle.js --ignore *bundle.js.map -e * --exec npm run build",
+    "build:watch": "nodemon --watch client --watch components --exec npm run build",
     "server": "node server/server.js",
-    "server:watch": "nodemon --delay 3 --watch server -e '*' --exec npm run server",
+    "server:watch": "nodemon --delay 3 --watch server --exec npm run server",
     "dev": " npm-run-all --parallel build:watch server:watch",
     "start": "npm-run-all --serial build server"
   },


### PR DESCRIPTION
I figured I would start off with something simple. I wasn't able to get this running on my mac and was able to track down the cause to the "allExtensions" param. I tested this on my windows machine and it works with either `'*'` or `*`. I didn't see any official documentation but [this](https://github.com/remy/nodemon/issues/915#issuecomment-445905946) comment leads me to believe that `'*'` is safe to switch to.