### PR TITLE
Disable sign in button when login form is invalid

### DIFF
--- a/components/forms/LoginForm.jsx
+++ b/components/forms/LoginForm.jsx
@@ -10,14 +10,49 @@ class LoginForm extends React.Component {
 
         this.state = {
             username: "",
-            password: ""
-        }
-
+            password: "",
+            isValid: false
+        };
+        this.validityMap = {
+            username: false,
+            password: false
+        };
         this.handleInputChange = this.handleInputChange.bind(this);
+        this.renderField = this.renderField.bind(this);
+        this.validateFields = this.validateFields.bind(this);
     }
 
     handleInputChange(name, value) {
         this.setState({[name]: value});
+    }
+
+    validateFields(key, value) {
+        this.validityMap[key] = value;
+        this.setState({
+            isValid: this.validityMap.username && this.validityMap.password
+        });
+    }
+
+    renderField(props) {
+        const { fieldName, ...remainingProps } = props;
+        return (
+            <TextValidator
+                id={fieldName}
+                key={fieldName}
+                validatorListener={result => {
+                    this.validateFields(fieldName, result);
+                }}
+                onChange={e =>
+                    this.handleInputChange(fieldName, e.target.value)
+                }
+                name={fieldName}
+                margin="dense"
+                withRequiredValidator={true}
+                autoComplete="off"
+                value={this.state[fieldName]}
+                {...remainingProps}
+            />
+        );
     }
 
     render() {
@@ -31,41 +66,39 @@ class LoginForm extends React.Component {
                 loading: saving
             }
         ];
-
+        const LoginField = this.renderField;
         props.autoComplete = "off";
         props.actions = actions;
 
         return (
-            <DialogForm {...props} method="POST">
+            <DialogForm
+                {...props}
+                disabledSubmit={!this.state.isValid}
+                method="POST"
+            >
                 <FormField>
                     <input type="hidden" name="redirect" value={redirect} />
-                    <TextValidator
-                        id="username"
-                        name="username"
+                    <LoginField
+                        fieldName="username"
                         placeholder="you@example.com"
                         label="e-mail"
-                        onChange={ (e) => this.handleInputChange(e.target.name, e.target.value)}
-                        margin="dense"
-                        validators={['required', 'isEmail']}
-                        errorMessages={['enter your username', 'not a valid email address']}
-                        withRequiredValidator={true}
-                        value={this.state.username}
-                        autoComplete="off"
-                        autoFocus />
+                        validators={["required", "isEmail"]}
+                        errorMessages={[
+                            "enter your username",
+                            "not a valid email address"
+                        ]}
+                        autoFocus
+                    />
                 </FormField>
                 <FormField>
-                    <TextValidator
-                            id="password"
-                            name="password"
-                            label="Password"
-                            onChange={ (e) => this.handleInputChange(e.target.name, e.target.value)}
-                            margin="dense"
-                            validators={['required']}
-                            errorMessages={['enter your password']}
-                            withRequiredValidator={true}
-                            value={this.state.password}
-                            autoComplete="off"
-                            type="password" />
+                    <LoginField
+                        fieldName="password"
+                        label="Password"
+                        validators={["required"]}
+                        errorMessages={["enter your password"]}
+                        value={this.state.password}
+                        type="password"
+                    />
                 </FormField>
             </DialogForm>
         );

--- a/components/forms/LoginForm.jsx
+++ b/components/forms/LoginForm.jsx
@@ -3,7 +3,7 @@ import DialogForm from "../layout/DialogForm";
 import FormField from "../forms/FormField";
 import TextValidator from "react-material-ui-form-validator/lib/TextValidator";
 
-class LoginForm extends React.Component {
+class LoginForm extends React.PureComponent {
 
     constructor(props) {
         super(props);
@@ -63,7 +63,8 @@ class LoginForm extends React.Component {
                 label: "Sign In",
                 formAction: "submit",
                 color: "primary",
-                loading: saving
+                loading: saving,
+                disabled: !this.state.isValid
             }
         ];
         const LoginField = this.renderField;
@@ -71,11 +72,7 @@ class LoginForm extends React.Component {
         props.actions = actions;
 
         return (
-            <DialogForm
-                {...props}
-                disabledSubmit={!this.state.isValid}
-                method="POST"
-            >
+            <DialogForm {...props} method="POST">
                 <FormField>
                     <input type="hidden" name="redirect" value={redirect} />
                     <LoginField
@@ -96,7 +93,6 @@ class LoginForm extends React.Component {
                         label="Password"
                         validators={["required"]}
                         errorMessages={["enter your password"]}
-                        value={this.state.password}
                         type="password"
                     />
                 </FormField>

--- a/components/layout/DialogForm.jsx
+++ b/components/layout/DialogForm.jsx
@@ -39,11 +39,12 @@ class DialogForm extends React.Component {
     }
 
     render() {
-        const {disabled, disabledSubmit, classes, actions, ...props} = this.props;
+        const {disabled, classes, actions, ...props} = this.props;
 
         if (!props.onSubmit) props.onSubmit = (e) => {
             e.nativeEvent.target.submit();
         }
+
         return (
             <ValidatorForm {...props}>
                 <fieldset disabled={disabled} className={classes.fieldSet}>
@@ -57,8 +58,8 @@ class DialogForm extends React.Component {
                     </DialogContent>
                     {actions &&
                         <DialogActions>
-                            {actions.map( ({callback, label, color, formAction, loading}, index) =>
-                                <IconButton type={formAction} key={index} disabled={disabled || disabledSubmit} loading={loading} onClick={formAction ? null : callback } color={color}>
+                            {actions.map( ({callback, label, color, formAction, loading, disabled: actionDisabled}, index) =>
+                                <IconButton type={formAction} key={index} disabled={disabled || actionDisabled} loading={loading} onClick={formAction ? null : callback } color={color}>
                                     {label}
                                 </IconButton>
                             )}

--- a/components/layout/DialogForm.jsx
+++ b/components/layout/DialogForm.jsx
@@ -39,12 +39,11 @@ class DialogForm extends React.Component {
     }
 
     render() {
-        const {disabled, classes, actions, ...props} = this.props;
+        const {disabled, disabledSubmit, classes, actions, ...props} = this.props;
 
         if (!props.onSubmit) props.onSubmit = (e) => {
             e.nativeEvent.target.submit();
         }
-
         return (
             <ValidatorForm {...props}>
                 <fieldset disabled={disabled} className={classes.fieldSet}>
@@ -59,7 +58,7 @@ class DialogForm extends React.Component {
                     {actions &&
                         <DialogActions>
                             {actions.map( ({callback, label, color, formAction, loading}, index) =>
-                                <IconButton type={formAction} key={index} disabled={disabled} loading={loading} onClick={formAction ? null : callback } color={color}>
+                                <IconButton type={formAction} key={index} disabled={disabled || disabledSubmit} loading={loading} onClick={formAction ? null : callback } color={color}>
                                     {label}
                                 </IconButton>
                             )}


### PR DESCRIPTION
This is a change to disable the submit button when the login form is invalid. 

About this change I'm not 100% sure if this is the right place to hold the validation state but couldn't figure out where the right place was. `DialogForm` Seemed like a better place because it renders the button, but it doesn't know anything about the children being passed in. I thought about adding some callbacks to the children to have them tell `DialogForm` when they are valid but thought that would be best put in another PR.

Screenshots:
![Screen Shot 2019-06-19 at 10 09 56 PM](https://user-images.githubusercontent.com/7918955/59820001-205f7580-92df-11e9-81c7-ca015d79c65e.png)
![Screen Shot 2019-06-19 at 10 10 09 PM](https://user-images.githubusercontent.com/7918955/59820002-205f7580-92df-11e9-96e3-e9f7fd728f9a.png)
